### PR TITLE
add Activej Benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
       <artifactId>serializer</artifactId>
       <version>1.3.2</version>
     </dependency>
+    <dependency>
+      <groupId>io.activej</groupId>
+      <artifactId>activej-serializer</artifactId>
+      <version>5.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/github/chaokunyang/fury/benchmark/ActivejBenchmark.java
+++ b/src/main/java/com/github/chaokunyang/fury/benchmark/ActivejBenchmark.java
@@ -1,0 +1,111 @@
+package com.github.chaokunyang.fury.benchmark;
+
+import com.github.chaokunyang.fury.benchmark.activejdata.Image;
+import com.github.chaokunyang.fury.benchmark.activejdata.Media;
+import com.github.chaokunyang.fury.benchmark.activejdata.MediaContent;
+import com.github.chaokunyang.fury.benchmark.activejdata.Struct;
+import io.activej.serializer.BinaryOutput;
+import io.activej.serializer.BinarySerializer;
+import io.activej.serializer.SerializerBuilder;
+import org.apache.fury.Fury;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ActivejBenchmark {
+  private static MediaContent mediaContent = new MediaContent().populate(false);
+  private static Struct struct = Struct.create();
+
+  static BinarySerializer<MediaContent> mediaContentSerializer = SerializerBuilder.create().build(MediaContent.class);
+  static BinarySerializer<Struct> structSerializer = SerializerBuilder.create().build(Struct.class);
+
+  // serialize a company
+  static byte[] mediaContentBytes;
+  static byte[] structBytes;
+  private static byte[] buffer = new byte[1024];
+  
+  static {
+    BinaryOutput output = new BinaryOutput(buffer);
+    mediaContentSerializer.encode(output, mediaContent);
+    mediaContentBytes = Arrays.copyOf(buffer, output.pos());
+    assert mediaContentSerializer.decode(mediaContentBytes, 0).equals(mediaContent);
+    output = new BinaryOutput(buffer);
+    structSerializer.encode(output, struct);
+    assert structSerializer.decode(structBytes, 0).equals(struct);
+    System.out.println("Activej mediaContentBytes size " + mediaContentBytes.length);
+    System.out.println("Activej structBytes size " + structBytes.length);
+  }
+
+  @Benchmark
+  public Object activejSerializeMediaContent() throws Exception {
+    BinaryOutput output = new BinaryOutput(buffer);
+    mediaContentSerializer.encode(output, mediaContent);
+    return Arrays.copyOf(buffer, output.pos());
+  }
+
+  @Benchmark
+  public Object activejDeserializeMediaContent() throws Exception {
+    return mediaContentSerializer.decode(mediaContentBytes, 0);
+  }
+
+  @Benchmark
+  public Object activejSerializeStruct() throws Exception {
+    BinaryOutput output = new BinaryOutput(buffer);
+    structSerializer.encode(output, struct);
+    return Arrays.copyOf(buffer, output.pos());
+  }
+
+  @Benchmark
+  public Object activejDeserializeStruct() throws Exception {
+    return structSerializer.decode(structBytes, 0);
+  }
+
+  private static Fury fury = Fury.builder().build(); // create once, reuse
+  private static byte[] furyMediaContentBytes;
+  private static byte[] furyStructBytes;
+
+  static {
+    fury.register(Struct.class);
+    fury.register(Image.class);
+    fury.register(Media.class);
+    fury.register(Image.Size.class);
+    fury.register(MediaContent.class);
+    fury.register(Media.Player.class);
+    furyMediaContentBytes = fury.serializeJavaObject(mediaContent);
+    furyStructBytes = fury.serializeJavaObject(struct);
+    System.out.println("furyMediaContentBytes size " + furyMediaContentBytes.length);
+    System.out.println("furyStructBytes size " + furyStructBytes.length);
+  }
+
+  @Benchmark
+  public Object furySerializeStruct() throws Exception {
+    return fury.serializeJavaObject(struct);
+  }
+
+  @Benchmark
+  public Object furyDeserializeStruct() throws Exception {
+    return fury.deserializeJavaObject(furyStructBytes, Struct.class);
+  }
+
+  @Benchmark
+  public Object furySerializeMediaContent() throws Exception {
+    return fury.serializeJavaObject(mediaContent);
+  }
+
+  @Benchmark
+  public Object furyDeserializeMediaContent() throws Exception {
+    return fury.deserializeJavaObject(furyMediaContentBytes, MediaContent.class);
+  }
+
+  public static void main(String[] args) throws IOException {
+    if (args.length == 0) {
+      String commandLine =
+        "com.*ActivejBenchmark.* -f 1 -wi 1 -i 1 -t 1 -w 2s -r 2s -rf csv";
+      System.out.println(commandLine);
+      args = commandLine.split(" ");
+    }
+    Main.main(args);
+  }
+}

--- a/src/main/java/com/github/chaokunyang/fury/benchmark/activejdata/Image.java
+++ b/src/main/java/com/github/chaokunyang/fury/benchmark/activejdata/Image.java
@@ -1,0 +1,106 @@
+/* Copyright (c) 2008-2023, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.github.chaokunyang.fury.benchmark.activejdata;
+
+import io.activej.serializer.annotations.Deserialize;
+import io.activej.serializer.annotations.Serialize;
+
+import java.io.Serializable;
+
+public class Image implements Serializable {
+  @Serialize
+  public String uri;
+  @Serialize
+  public String title; // Can be null.
+  @Serialize
+  public int width;
+  @Serialize
+  public int height;
+  @Serialize
+  public Size size;
+  @Serialize
+  public Media media; // Can be null.
+
+  public Image() {
+  }
+
+  public Image(@Deserialize("uri") String uri, @Deserialize("title") String title,
+               @Deserialize("width") int width, @Deserialize("height") int height,
+               @Deserialize("size") Size size, @Deserialize("media") Media media) {
+    this.height = height;
+    this.title = title;
+    this.uri = uri;
+    this.width = width;
+    this.size = size;
+    this.media = media;
+  }
+
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Image other = (Image) o;
+    if (height != other.height) {
+      return false;
+    }
+    if (width != other.width) {
+      return false;
+    }
+    if (size != other.size) {
+      return false;
+    }
+    if (title != null ? !title.equals(other.title) : other.title != null) {
+      return false;
+    }
+    if (uri != null ? !uri.equals(other.uri) : other.uri != null) {
+      return false;
+    }
+    return true;
+  }
+
+  public int hashCode() {
+    int result = uri != null ? uri.hashCode() : 0;
+    result = 31 * result + (title != null ? title.hashCode() : 0);
+    result = 31 * result + width;
+    result = 31 * result + height;
+    result = 31 * result + (size != null ? size.hashCode() : 0);
+    return result;
+  }
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("[Image ");
+    sb.append("uri=").append(uri);
+    sb.append(", title=").append(title);
+    sb.append(", width=").append(width);
+    sb.append(", height=").append(height);
+    sb.append(", size=").append(size);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  public enum Size {
+    SMALL,
+    LARGE
+  }
+}

--- a/src/main/java/com/github/chaokunyang/fury/benchmark/activejdata/Media.java
+++ b/src/main/java/com/github/chaokunyang/fury/benchmark/activejdata/Media.java
@@ -1,0 +1,169 @@
+/* Copyright (c) 2008-2023, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.github.chaokunyang.fury.benchmark.activejdata;
+
+import io.activej.serializer.annotations.Deserialize;
+import io.activej.serializer.annotations.Serialize;
+import io.avaje.jsonb.Json;
+
+import java.util.List;
+
+public class Media implements java.io.Serializable {
+  @Serialize
+  public String uri;
+  @Serialize
+  public String title; // Can be null.
+  @Serialize
+  public int width;
+  @Serialize
+  public int height;
+  @Serialize
+  public String format;
+  @Serialize
+  public long duration;
+  @Serialize
+  public long size;
+  @Serialize
+  public int bitrate;
+  @Serialize
+  public boolean hasBitrate;
+  @Serialize
+  public List<String> persons;
+  @Serialize
+  public Player player;
+  @Serialize
+  public String copyright; // Can be null.
+
+  public Media() {}
+
+  public Media(
+    @Deserialize("uri")    String uri,
+    @Deserialize("title")    String title,
+    @Deserialize("width")    int width,
+    @Deserialize("height")     int height,
+    @Deserialize("format")    String format,
+    @Deserialize("duration")   long duration,
+    @Deserialize("size")     long size,
+    @Deserialize("bitrate")    int bitrate,
+    @Deserialize("hasBitrate")    boolean hasBitrate,
+    @Deserialize("persons")    List<String> persons,
+    @Deserialize("player")    Player player,
+    @Deserialize("copyright")    String copyright) {
+    this.uri = uri;
+    this.title = title;
+    this.width = width;
+    this.height = height;
+    this.format = format;
+    this.duration = duration;
+    this.size = size;
+    this.bitrate = bitrate;
+    this.hasBitrate = hasBitrate;
+    this.persons = persons;
+    this.player = player;
+    this.copyright = copyright;
+  }
+
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Media other = (Media) o;
+    if (bitrate != other.bitrate) {
+      return false;
+    }
+    if (duration != other.duration) {
+      return false;
+    }
+    if (hasBitrate != other.hasBitrate) {
+      return false;
+    }
+    if (height != other.height) {
+      return false;
+    }
+    if (size != other.size) {
+      return false;
+    }
+    if (width != other.width) {
+      return false;
+    }
+    if (copyright != null ? !copyright.equals(other.copyright) : other.copyright != null) {
+      return false;
+    }
+    if (format != null ? !format.equals(other.format) : other.format != null) {
+      return false;
+    }
+    if (persons != null ? !persons.equals(other.persons) : other.persons != null) {
+      return false;
+    }
+    if (player != other.player) {
+      return false;
+    }
+    if (title != null ? !title.equals(other.title) : other.title != null) {
+      return false;
+    }
+    if (uri != null ? !uri.equals(other.uri) : other.uri != null) {
+      return false;
+    }
+    return true;
+  }
+
+  public int hashCode() {
+    int result = uri != null ? uri.hashCode() : 0;
+    result = 31 * result + (title != null ? title.hashCode() : 0);
+    result = 31 * result + width;
+    result = 31 * result + height;
+    result = 31 * result + (format != null ? format.hashCode() : 0);
+    result = 31 * result + (int) (duration ^ (duration >>> 32));
+    result = 31 * result + (int) (size ^ (size >>> 32));
+    result = 31 * result + bitrate;
+    result = 31 * result + (hasBitrate ? 1 : 0);
+    result = 31 * result + (persons != null ? persons.hashCode() : 0);
+    result = 31 * result + (player != null ? player.hashCode() : 0);
+    result = 31 * result + (copyright != null ? copyright.hashCode() : 0);
+    return result;
+  }
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("[Media ");
+    sb.append("uri=").append(uri);
+    sb.append(", title=").append(title);
+    sb.append(", width=").append(width);
+    sb.append(", height=").append(height);
+    sb.append(", format=").append(format);
+    sb.append(", duration=").append(duration);
+    sb.append(", size=").append(size);
+    sb.append(", hasBitrate=").append(hasBitrate);
+    sb.append(", bitrate=").append(String.valueOf(bitrate));
+    sb.append(", persons=").append(persons);
+    sb.append(", player=").append(player);
+    sb.append(", copyright=").append(copyright);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  public enum Player {
+    JAVA,
+    FLASH;
+  }
+}

--- a/src/main/java/com/github/chaokunyang/fury/benchmark/activejdata/MediaContent.java
+++ b/src/main/java/com/github/chaokunyang/fury/benchmark/activejdata/MediaContent.java
@@ -1,0 +1,101 @@
+/* Copyright (c) 2008-2023, Nathan Sweet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.github.chaokunyang.fury.benchmark.activejdata;
+
+import io.activej.serializer.annotations.Deserialize;
+import io.activej.serializer.annotations.Serialize;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MediaContent implements java.io.Serializable {
+  @Serialize public Media media;
+  @Serialize  public List<Image> images;
+
+  public MediaContent() {}
+
+  public MediaContent(@Deserialize("media") Media media, @Deserialize("images") List<Image> images) {
+    this.media = media;
+    this.images = images;
+  }
+
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MediaContent other = (MediaContent) o;
+    if (images != null ? !images.equals(other.images) : other.images != null) {
+      return false;
+    }
+    if (media != null ? !media.equals(other.media) : other.media != null) {
+      return false;
+    }
+    return true;
+  }
+
+  public int hashCode() {
+    int result = media != null ? media.hashCode() : 0;
+    result = 31 * result + (images != null ? images.hashCode() : 0);
+    return result;
+  }
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("[MediaContent: ");
+    sb.append("media=").append(media);
+    sb.append(", images=").append(images);
+    sb.append("]");
+    return sb.toString();
+  }
+
+  public MediaContent populate(boolean circularReference) {
+    media = new Media();
+    media.uri = "http://javaone.com/keynote.ogg";
+    media.width = 641;
+    media.height = 481;
+    media.format = "video/theora\u1234";
+    media.duration = 18000001;
+    media.size = 58982401;
+    media.persons = new ArrayList();
+    media.persons.add("Bill Gates, Jr.");
+    media.persons.add("Steven Jobs");
+    media.player = Media.Player.FLASH;
+    media.copyright = "Copyright (c) 2009, Scooby Dooby Doo";
+    images = new ArrayList();
+    Media media = circularReference ? this.media : null;
+    images.add(
+        new Image(
+            "http://javaone.com/keynote_huge.jpg",
+            "Javaone Keynote\u1234",
+            32000,
+            24000,
+            Image.Size.LARGE,
+            media));
+    images.add(
+        new Image(
+            "http://javaone.com/keynote_large.jpg", null, 1024, 768, Image.Size.LARGE, media));
+    images.add(
+        new Image("http://javaone.com/keynote_small.jpg", null, 320, 240, Image.Size.SMALL, media));
+    return this;
+  }
+}

--- a/src/main/java/com/github/chaokunyang/fury/benchmark/activejdata/Struct.java
+++ b/src/main/java/com/github/chaokunyang/fury/benchmark/activejdata/Struct.java
@@ -1,0 +1,120 @@
+package com.github.chaokunyang.fury.benchmark.activejdata;
+
+import io.activej.serializer.annotations.Deserialize;
+import io.activej.serializer.annotations.Serialize;
+import org.apache.fury.reflect.ReflectionUtils;
+
+import java.util.Objects;
+
+public class Struct {
+  @Serialize
+  public int f1;
+  @Serialize
+  public int f2;
+  @Serialize
+  public long f3;
+  @Serialize
+  public long f4;
+  @Serialize
+  public float f5;
+  @Serialize
+  public float f6;
+  @Serialize
+  public double f7;
+  @Serialize
+  public double f8;
+  @Serialize
+  public int f9;
+  @Serialize
+  public int f10;
+  @Serialize
+  public long f11;
+  @Serialize
+  public long f12;
+  @Serialize
+  public float f13;
+  @Serialize
+  public float f14;
+  @Serialize
+  public double f15;
+  @Serialize
+  public double f16;
+
+  public Struct() {
+
+  }
+  
+  public Struct(@Deserialize("f1") int f1, @Deserialize("f2") int f2,
+                @Deserialize("f3") long f3, @Deserialize("f4") long f4,
+                @Deserialize("f5") float f5, @Deserialize("f6") float f6,
+                @Deserialize("f7") double f7, @Deserialize("f8") double f8,
+                @Deserialize("f9") int f9, @Deserialize("f10") int f10,
+                @Deserialize("f11") long f11, @Deserialize("f12") long f12,
+                @Deserialize("f13") float f13, @Deserialize("f14") float f14,
+                @Deserialize("f15") double f15, @Deserialize("f16") double f16) {
+    this.f1 = f1;
+    this.f2 = f2;
+    this.f3 = f3;
+    this.f4 = f4;
+    this.f5 = f5;
+    this.f6 = f6;
+    this.f7 = f7;
+    this.f8 = f8;
+    this.f9 = f9;
+    this.f10 = f10;
+    this.f11 = f11;
+    this.f12 = f12;
+    this.f13 = f13;
+    this.f14 = f14;
+    this.f15 = f15;
+    this.f16 = f16;
+  }
+
+  public static Struct create() {
+    Struct struct = new Struct();
+    com.github.chaokunyang.fury.benchmark.record.data.Struct struct1
+      = com.github.chaokunyang.fury.benchmark.record.data.Struct.create();
+    ReflectionUtils.unsafeCopy(struct1, struct);
+    return struct;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Struct struct = (Struct) o;
+    return f1 == struct.f1 && f2 == struct.f2 && f3 == struct.f3 && f4 == struct.f4 && Float.compare(struct.f5, f5) == 0 && Float.compare(struct.f6, f6) == 0 && Double.compare(struct.f7, f7) == 0 && Double.compare(struct.f8, f8) == 0 && f9 == struct.f9 && f10 == struct.f10 && f11 == struct.f11 && f12 == struct.f12 && Float.compare(struct.f13, f13) == 0 && Float.compare(struct.f14, f14) == 0 && Double.compare(struct.f15, f15) == 0 && Double.compare(struct.f16, f16) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16);
+  }
+
+  @Override
+  public String toString() {
+    return "Struct{" +
+      "f1=" + f1 +
+      ", f2=" + f2 +
+      ", f3=" + f3 +
+      ", f4=" + f4 +
+      ", f5=" + f5 +
+      ", f6=" + f6 +
+      ", f7=" + f7 +
+      ", f8=" + f8 +
+      ", f9=" + f9 +
+      ", f10=" + f10 +
+      ", f11=" + f11 +
+      ", f12=" + f12 +
+      ", f13=" + f13 +
+      ", f14=" + f14 +
+      ", f15=" + f15 +
+      ", f16=" + f16 +
+      '}';
+  }
+
+  public static void main(String[] args) {
+    System.out.println(create());
+  }
+}


### PR DESCRIPTION
Activej needs annotate all fields, which is very inconvenient, and it doesn't support field value which can be null.

Currently it throws following exception:
```java
Caused by: java.lang.NullPointerException: Cannot invoke "String.length()" because "s" is null
	at io.activej.serializer.util.BinaryOutputUtils.writeUTF8(BinaryOutputUtils.java:196)
	at io.activej.codegen.java.lang.Object_1.encode_Media(Unknown Source)
	at io.activej.codegen.java.lang.Object_1.encode(Unknown Source)
	at com.github.chaokunyang.fury.benchmark.ActivejBenchmark.<clinit>(ActivejBenchmark.java:31)
```
